### PR TITLE
Fix warning regarding string interpolation for Swift 3.1

### DIFF
--- a/Pod/Classes/TimeZoneLocate.swift
+++ b/Pod/Classes/TimeZoneLocate.swift
@@ -99,7 +99,7 @@ open class TimeZoneLocate : NSObject {
         }
         
         //let filePath = currentBundle.resourcePath
-        assertionFailure("Error loading or parse timeZoneDB file: \(filePath)")
+        assertionFailure("Error loading or parse timeZoneDB file: \(filePath ?? "filePath is nil")")
         return [[AnyHashable: Any]]()
     }
     


### PR DESCRIPTION
Fixed the warning:
String interpolation produces a debug description for an optional value; did you mean to make this explicit?